### PR TITLE
add libffi-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:16.04
 # Install the build requirements for Python.
 RUN apt-get update -y && \
     apt-get install -y gcc make curl \
-        libssl-dev libsqlite3-dev liblzma-dev libbz2-dev libgdbm-dev
+        libssl-dev libsqlite3-dev liblzma-dev libbz2-dev libgdbm-dev libffi-dev
 
 # Install the Makefile and exclude list, and build Python.
 # This Makefile will assume there are two external mountpoints:


### PR DESCRIPTION
This was sufficient to get ctypes to import successfully in the Linux support package, and _may_ fix https://github.com/beeware/briefcase/issues/407

I'm sure you'll know a better way to test/confirm this, but I tested by running `make` locally, then uploading the `dist/Python-3.8-linux-x86_64-support.b1` somewhere I could access it on CI... then in github actions, downloaded, expanded, and ran `python -c "import ctypes"` ... It [worked](https://github.com/tlambert03/brieftest/runs/710448835?check_suite_focus=true#step:5:101), but had previously [failed](https://github.com/tlambert03/brieftest/runs/706757611?check_suite_focus=true#step:5:88) with the current support package.