### PR TITLE
fix missing zlib module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ FROM ubuntu:18.04
 # Install the build requirements for Python.
 RUN apt-get update -y && \
     apt-get install -y gcc make curl \
-        libssl-dev libsqlite3-dev liblzma-dev libbz2-dev libgdbm-dev libffi-dev
+        libssl-dev libsqlite3-dev liblzma-dev libbz2-dev libgdbm-dev \
+        libffi-dev zlib1g-dev
 
 # Install the Makefile and exclude list, and build Python.
 # This Makefile will assume there are two external mountpoints:


### PR DESCRIPTION
The zlib module is silently missing now, as the Ubuntu 18.04 Docker image doesn't have `zlib.h` installed by default, which `setup.py` in the Python build looks for to determine whether to build the zlib extension. Unfortunately, there's no `--with-zlib` configure switch or equivalent that I could find, which would help enforce that the zlib module is built, preventing this breakage again in the future.

Tested the 3.6-3.9 builds with this commit trivially merged into those branches, and verified that the zlib extension was built. See `geogriff/3.6`, `geogriff/3.7`, `geogriff/3.8`, and `geogriff/3.9` in the `geogriff/python-linux-support` repo.