### PR TITLE
Use patchelf to ensure python binary is internally linked.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:18.04
 # Install the build requirements for Python.
 RUN apt-get update -y && \
     apt-get install -y \
-        gcc make curl \
+        gcc make patchelf curl \
         libbz2-dev \
         libffi-dev \
         libgdbm-compat-dev \

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ build/python/bin/python$(PYTHON_VER): build/Python-$(PYTHON_VERSION)/python.exe
 	cd build/Python-$(PYTHON_VERSION) && \
 		make install \
 			2>&1 | tee -a ../python-$(PYTHON_VERSION).install.log
+	# Make the binary and libpython3.so relocatable
+	patchelf --set-rpath "\$$ORIGIN/../lib" build/python/bin/python$(PYTHON_VER)
+	patchelf --set-rpath "\$$ORIGIN" build/python/lib/libpython3.so
 
 build/python/VERSIONS: dependencies
 	echo "Python version: $(PYTHON_VERSION) " > build/python/VERSIONS


### PR DESCRIPTION
Reported via https://github.com/beeware/briefcase/discussions/793

The `python3.10` binary and the `libpython3.so` produced in the 3.7-b5, 3.8-b5, 3.9-b3 and 3.10-b2 support packages were compiled with the `--enable-shared` flag. This means they have been dynamically linked; but the files have an rpath set for an location that isn't relocatable.

If the user who uses the support package has a /usr/lib/.../libpython3.10.so installed on their system (as will be the case if they're building in Briefcase's Docker environment, or they have a python3-dev package installed in their system), this won't pose a problem, as linuxdeploy will resolve the binary using the system-provided library. However, if you don't have that library available at the system level, the AppImage fails to build.

This PR patches the binary and .so after installation so that it is relocatable. It would be nice if we could get this as a direct output of the cpython build process but python/cpython#80262 prevents that.

Thanks to @AnkS4 for the original report, and @rmartin16 for narrowing down the cause and the draft solution.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
